### PR TITLE
fix(docker): update Dockerfile configuration for HTTPX compatibility

### DIFF
--- a/docker/httpx/Dockerfile
+++ b/docker/httpx/Dockerfile
@@ -1,9 +1,18 @@
-FROM golang:1.21-alpine
+FROM alpine:edge
 
-RUN apk add --no-cache git
+# Add community and testing repos (needed for latest Go)
+RUN echo "https://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories && \
+    echo "https://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories && \
+    apk update && \
+    apk add --no-cache go git
+
+ENV GOPATH=/go
+ENV PATH=$GOPATH/bin:/usr/local/go/bin:$PATH
+
+# ✅ Now you can install the latest httpx (v1.7.0+)
 RUN go install -v github.com/projectdiscovery/httpx/cmd/httpx@latest
 
 WORKDIR /app
 RUN mkdir -p /data && chmod 777 /data
 
-ENTRYPOINT ["httpx"] 
+ENTRYPOINT ["httpx"]

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,9 +1,16 @@
-FROM golang:1.21-alpine
+FROM alpine:edge
 
-# Install required packages
-RUN apk add --no-cache git gcc musl-dev docker
+# Add community + testing for Go 1.24, then install Go and tools
+RUN echo "https://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories && \
+    echo "https://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories && \
+    apk update && \
+    apk add --no-cache go git gcc musl-dev docker
 
-# Install httpx
+# Setup Go environment
+ENV GOPATH=/go
+ENV PATH=$GOPATH/bin:/usr/local/go/bin:$PATH
+
+# Install latest httpx (needs Go >= 1.23)
 RUN go install -v github.com/projectdiscovery/httpx/cmd/httpx@latest
 
 WORKDIR /app
@@ -13,8 +20,7 @@ RUN go mod download
 
 COPY . .
 
-RUN mkdir -p /app/temp
-RUN chmod -R 777 /app/temp
+RUN mkdir -p /app/temp && chmod -R 777 /app/temp
 
 RUN go build -o main .
 


### PR DESCRIPTION

Refactored Dockerfiles under `docker/httpx/` and `server/` directories to ensure compatibility with the latest version of [`httpx`](https://github.com/projectdiscovery/httpx) and improve Docker build reliability.

---

#### Changes:

- **Base Image:**
  - Replaced `golang:1.21-alpine` with `alpine:edge` for greater flexibility.
  
- **Repository Configuration:**
  - Added `community` and `testing` Alpine repositories to install the latest Go and other dependencies.

- **Go Installation:**
  - Installed Go manually using `apk` to support `httpx@latest`, which requires Go ≥ 1.23.

- **Environment Setup:**
  - Defined `GOPATH` and appended Go paths to `PATH` environment variable.

- **httpx Installation:**
  - Installed `httpx` using `go install -v github.com/projectdiscovery/httpx/cmd/httpx@latest`.

- **Permissions & Directories:**
  - Created and set permissions for `/app/temp` and `/data` directories to support app runtime.

---