### PR TITLE
Requires go version >= 1.23.0

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21-alpine
+FROM golang:1.23-alpine
 
 # Install required packages
 RUN apk add --no-cache git gcc musl-dev docker


### PR DESCRIPTION
I run this framework on ubuntu 22.04 get the error:

```=> ERROR [api  3/10] RUN go install -v github.com/projectdiscovery/httpx/cmd/httpx@latest                                        2.7s
------
 > [api  3/10] RUN go install -v github.com/projectdiscovery/httpx/cmd/httpx@latest:
1.684 go: downloading github.com/projectdiscovery/httpx v1.7.0
2.453 go: github.com/projectdiscovery/httpx/cmd/httpx@latest: github.com/projectdiscovery/httpx@v1.7.0 requires go >= 1.23.0 (running go 1.21.13; GOTOOLCHAIN=local)
------
failed to solve: process "/bin/sh -c go install -v github.com/projectdiscovery/httpx/cmd/httpx@latest" did not complete successfully: exit code: 1
```


So, i upgrade the golang version in server to 1.23.0