### PR TITLE
Fix parallelism flag for Katana in metaDataUtils.go

### DIFF
--- a/server/utils/metaDataUtils.go
+++ b/server/utils/metaDataUtils.go
@@ -247,7 +247,7 @@ func ExecuteAndParseMetaDataScan(scanID, domain string) {
 			"-v",
 			"-timeout", "30",
 			"-c", "15",
-			"p", "15",
+			"-p", "15",
 		)
 
 		katanaCmd.WaitDelay = 30 * time.Second


### PR DESCRIPTION
Parallelism flag missing dash for Katana