### PR TITLE
fix(docker): make GAU compatible with ARM64 (M4 Mac)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ client/node_modules
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+# IDE
+.idea/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -209,6 +209,18 @@ services:
     networks:
       - ars0n-network
 
+  gau:
+    container_name: ars0n-framework-v2-gau-1
+    build: ./docker/gau
+    depends_on:
+      - api
+    volumes:
+      - temp_data:/tmp
+    entrypoint: [ "sleep", "infinity" ]
+    restart: "no"
+    networks:
+      - ars0n-network
+
   dnsx:
     container_name: ars0n-framework-v2-dnsx-1
     build: ./docker/dnsx

--- a/docker/gau/Dockerfile
+++ b/docker/gau/Dockerfile
@@ -1,0 +1,15 @@
+FROM golang:1.24-alpine AS builder
+
+RUN apk add --no-cache git
+
+RUN CGO_ENABLED=0 go install github.com/lc/gau/v2/cmd/gau@latest
+
+FROM alpine:3.20
+
+WORKDIR /app
+
+COPY --from=builder /go/bin/gau /usr/local/bin/gau
+
+RUN gau -version || echo "gau installed successfully"
+
+ENTRYPOINT ["gau"]

--- a/server/utils/subdomainScrapingUtils.go
+++ b/server/utils/subdomainScrapingUtils.go
@@ -655,8 +655,9 @@ func ExecuteAndParseGauScan(scanID, domain string) {
 
 	// Build base command
 	dockerCmd := []string{
-		"docker", "run", "--rm",
-		"sxcurity/gau:latest",
+		"docker", "exec", "-i",
+		"ars0n-framework-v2-gau-1",
+		"gau",
 		domain,
 		"--providers", "wayback",
 		"--json",
@@ -697,8 +698,9 @@ func ExecuteAndParseGauScan(scanID, domain string) {
 	if result == "" {
 		// Try a second attempt with different flags
 		dockerCmd = []string{
-			"docker", "run", "--rm",
-			"sxcurity/gau:latest",
+			"docker", "exec", "-i",
+			"ars0n-framework-v2-gau-1",
+			"gau",
 			domain,
 			"--providers", "wayback,otx,urlscan",
 			"--subs",


### PR DESCRIPTION
### Problem
GAU scans fail on ARM64 host – tested on my M4 Mac – because the official Docker image `sxcurity/gau:latest` only supports x86_64. 

```zsh
➜ ars0n-framework-v2 git:(main) ✗ docker run --rm sxcurity/gau:latest <DOMAIN> --providers wayback --json --verbose --subs --threads 10 --timeout 60 --retries 2 

Unable to find image 'sxcurity/gau:latest' locally docker: Error response from daemon: no matching manifest for linux/arm64/v8 in the manifest list entries: no match for platform in manifest: not found Run 'docker run --help' for more information
```

There is also a discussion topic [here](https://github.com/R-s0n/ars0n-framework-v2/discussions/25).
