### PR TITLE
[FIX] Change PostgreSQL image version to 13

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,7 +43,7 @@ services:
 
   db:
     container_name: ars0n-framework-v2-db-1
-    image: postgres:latest
+    image: postgres:13
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres


### PR DESCRIPTION
Latest PostgreSQL version (18.*) is different from v13 but with latest version it seems not working correctly... when changing to PostgreSQL v13 it works [OS: Athena OS] Based on [ARCH] 
<img width="1191" height="675" alt="Screenshot From 2025-12-02 00-38-37" src="https://github.com/user-attachments/assets/865c9c27-f7b1-4102-844f-277bae9c7ebf" />
sudo pacman -S R-s0n-Hero